### PR TITLE
use released versions of gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 # sul-dlss gems: get latest versions from master, rather than released gems
-gem 'gdor-indexer', github: 'sul-dlss/gdor-indexer'
-gem 'harvestdor-indexer', github: "sul-dlss/harvestdor-indexer"
-gem "harvestdor", github: "sul-dlss/harvestdor"
 gem 'blacklight-spotlight', github: 'sul-dlss/spotlight'
 
 group :test do

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,4 +1,1 @@
-gem 'gdor-indexer', github: 'sul-dlss/gdor-indexer'
-gem 'harvestdor-indexer', github: "sul-dlss/harvestdor-indexer"
-gem "harvestdor", github: "sul-dlss/harvestdor"
 gem 'blacklight-spotlight', github: 'sul-dlss/spotlight'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -4,15 +4,15 @@ class TestAppGenerator < Rails::Generators::Base
   source_root "../../spec/test_app_templates"
 
   def add_gems
-    gem 'blacklight', '~> 5.1'     
-    gem "blacklight-spotlight"
+    gem 'blacklight', '~> 5.1'
+    gem "blacklight-spotlight", github: 'sul-dlss/spotlight'
     Bundler.with_clean_env do
       run "bundle install"
     end
   end
 
   def run_blacklight_generator
-    say_status("warning", "GENERATING BL", :yellow)  
+    say_status("warning", "GENERATING BL", :yellow)
     generate 'blacklight:install', '--devise --jettywrapper'
   end
 

--- a/spotlight-dor-resources.gemspec
+++ b/spotlight-dor-resources.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday"
-  spec.add_dependency 'harvestdor'
   spec.add_dependency 'solrizer'
-  spec.add_dependency 'harvestdor-indexer'
+  spec.add_dependency 'gdor-indexer'
   spec.add_dependency "rails"
   spec.add_dependency "blacklight-spotlight", "~> 0.2"
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
Use released versions of:
* gdor-indexer
* harvestdor-indexer
* harvestdor

@cbeer:  Oddly, I had to give the blacklight-spotlight gem github location in TestAppGenerator.add_gems.  Without it, it would complain that I wanted it from github and from '.'.  I don't understand why Gemfile.extra wasn't enough.

Connects to sul-dlss/spotlight#1204