### PR TITLE
Index folder name - feigenbaum specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ capybara-*.html
 /db/*.sqlite3
 /public/system/*
 /coverage/
+/pkg/
 /spec/tmp/*
 **.orig
 rerun.txt

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ AllCops:
   Exclude:
     - 'spec/internal/**/*'
     - 'spec/test_app_templates/**/*'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/spotlight/dor/indexer.rb'

--- a/lib/spotlight/dor/indexer.rb
+++ b/lib/spotlight/dor/indexer.rb
@@ -31,8 +31,8 @@ module Spotlight::Dor
     end
 
     # add fields from raw mods
-    # see comment with add_donor_tags about Feigenbaum specific donor tags data
     before_index :add_box
+    # see comment with add_donor_tags about Feigenbaum specific donor tags data
     before_index :add_donor_tags
     before_index :add_genre
     before_index :add_folder
@@ -73,7 +73,7 @@ module Spotlight::Dor
 
     # This new donor_tags_sim field was added in October 2015 specifically for the Feigenbaum exhibit.  It is very likely
     #  it will go ununsed by other projects, but should be benign (since this field will not be created if this specific MODs note is not found.)
-    #  Later refactoring could include project specific fields.   Peter Mangiafico
+    #  Later refactoring could include exhibit specific fields.   Peter Mangiafico
     def add_donor_tags sdb, solr_doc
       donor_tags = sdb.smods_rec.note.select { |n| n.displayLabel == 'Donor tags' }.map(&:content)
       insert_field solr_doc, 'donor_tags', donor_tags, :symbol # this is a _ssim field

--- a/lib/spotlight/dor/indexer.rb
+++ b/lib/spotlight/dor/indexer.rb
@@ -36,6 +36,7 @@ module Spotlight::Dor
     before_index :add_donor_tags
     before_index :add_genre
     before_index :add_folder
+    before_index :add_folder_name
     before_index :add_series
     before_index :mods_cartographics_indexing
 
@@ -99,6 +100,15 @@ module Spotlight::Dor
       end
 
       solr_doc['folder_ssi'] = folder_num.first if folder_num.present?
+    end
+
+    # add the folder name to solr_doc as folder_name_ssi field (note: single valued!)
+    #   data is specific to Feigenbaum collection and is in <note type='preferred citation'>
+    def add_folder_name(sdb, solr_doc)
+      # see spec for data examples
+      preferred_citation = sdb.smods_rec.note.select { |n| n.type_at == 'preferred citation' }.map(&:content)
+      match_data = preferred_citation.first.match(/Title: +(.+)/i) if preferred_citation.present?
+      solr_doc['folder_name_ssi'] = match_data[1].rstrip if match_data.present?
     end
 
     # add plain MODS <genre> element data, not the SearchWorks genre values

--- a/spotlight-dor-resources.gemspec
+++ b/spotlight-dor-resources.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Chris Beer"]
   spec.email         = ["cabeer@stanford.edu"]
   spec.summary       = "Spotlight resource indexer for DOR resources."
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/sul-dlss/spotlight-dor-resources"
   spec.license       = "Apache 2"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
This is a Feigenbaum specific indexing need - to pull the "Title" value off the end of a MODS '<note type="preferred citation">' value and index it.  (In saltworks, this was a facet called "subseries")

Connects to sul-dlss/sul-exhibits-template#52