### PR TITLE
Use the appropriately suffixed field name for the coordinates field

### DIFF
--- a/lib/spotlight/dor/indexer.rb
+++ b/lib/spotlight/dor/indexer.rb
@@ -53,7 +53,7 @@ module Spotlight::Dor
       # add coordinates solr field containing the cartographic coordinates per
       # MODS subject.cartographics.coordinates (via stanford-mods gem)
       def add_coordinates(sdb, solr_doc)
-        solr_doc['coordinates'] = sdb.smods_rec.coordinates
+        solr_doc['coordinates_tesim'] = sdb.smods_rec.coordinates
       end
 
       # add collector_ssim solr field containing the collector per MODS names (via stanford-mods gem)

--- a/spec/lib/spotlight/dor/indexer_spec.rb
+++ b/spec/lib/spotlight/dor/indexer_spec.rb
@@ -369,7 +369,7 @@ describe Spotlight::Dor::Indexer do
         end
 
         it 'is blank' do
-          expect(solr_doc['coordinates']).to be_blank
+          expect(solr_doc['coordinates_tesim']).to be_blank
         end
       end
       context 'with a record with coordinates' do
@@ -388,7 +388,7 @@ describe Spotlight::Dor::Indexer do
         end
 
         it 'extracts the coordinates' do
-          expect(solr_doc['coordinates']).to eq(['(W16°--E28°/N13°--S15°).'])
+          expect(solr_doc['coordinates_tesim']).to eq(['(W16°--E28°/N13°--S15°).'])
         end
       end
     end # add_coordinates


### PR DESCRIPTION
Fixes #56