### PR TITLE
update to gdor-indexing 0.4.1 for fixed pub year field values

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ require 'exhibits_solr_conf'
 desc 'Run tests in generated test Rails app with generated Solr instance running'
 task ci: ['engine_cart:generate', 'jetty:clean', 'exhibits:configure_solr'] do
   ENV['environment'] = 'test'
+  ENV['TEST_JETTY_PORT'] = '8983'
   jetty_params = Jettywrapper.load_config
   jetty_params[:startup_wait] = 60
 

--- a/spec/integration/gdor_integration_spec.rb
+++ b/spec/integration/gdor_integration_spec.rb
@@ -27,4 +27,12 @@ describe 'gdor indexing integration test', :vcr do
   it 'has exhibit-specific indexing' do
     expect(subject).to include 'full_image_url_ssm'
   end
+
+  it 'can write doc to solr with latest exhibits_solr_conf', vcr: false do
+    # hd778hw9236 has B.C. date -- good for checking Solr field types
+    r = Spotlight::Resources::Purl.new(url: 'https://purl.stanford.edu/hd778hw9236')
+    allow(r).to receive(:to_global_id).and_return('x')
+    allow(r).to receive(:exhibit).and_return(exhibit)
+    r.reindex
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ VCR.configure do |config|
   config.cassette_library_dir = "spec/vcr_cassettes"
   config.hook_into :webmock
   config.configure_rspec_metadata!
+  config.allow_http_connections_when_no_cassette = true
 end
 
 RSpec.configure do |config|

--- a/spotlight-dor-resources.gemspec
+++ b/spotlight-dor-resources.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday'
   spec.add_dependency 'solrizer'
-  spec.add_dependency 'gdor-indexer', '>=0.4.0' # for new pub date methods
+  spec.add_dependency 'gdor-indexer', '>=0.4.1' # for new pub date methods
   # newer versions of harvestdor-indexer have performance improvements for collections
   spec.add_dependency 'harvestdor-indexer', '~> 2.3'
   spec.add_dependency 'rails'


### PR DESCRIPTION
also write an integration spec so we know when we are trying to write an invalid doc hash to Solr (e.g.  "300 B.C." in an int field)

connects to #53 