### PR TITLE
update to gdor-indexer 0.5.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,10 +13,18 @@ AllCops:
     - 'spec/spec_helper.rb'
     - 'spec/teaspoon_env.rb'
     - 'vendor/**/*'
-  RunRailsCops: true
+  Rails:
+    Enabled: true
+  TargetRubyVersion: 2.2
 
 Metrics/LineLength:
   Max: 130
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
 
 Style/StringLiterals:
   Enabled: true
@@ -25,3 +33,6 @@ Style/StringLiterals:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/integration/*'
+
+RSpec/FilePath:
+  Enabled: false

--- a/spec/lib/spotlight/dor/indexer_spec.rb
+++ b/spec/lib/spotlight/dor/indexer_spec.rb
@@ -572,7 +572,6 @@ describe Spotlight::Dor::Indexer do
     end # add_series
   end # context StanfordMods concern
 
-  # rubocop:disable Metrics/LineLength
   context 'Full Text Indexing concern' do
     describe '#add_object_full_text' do
       let(:full_text_solr_fname) { 'full_text_tesimv' }
@@ -649,5 +648,4 @@ describe Spotlight::Dor::Indexer do
       end
     end # add_object_full_text
   end # full text indexing concern
-  # rubocop:enable Metrics/LineLength
 end

--- a/spotlight-dor-resources.gemspec
+++ b/spotlight-dor-resources.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday'
   spec.add_dependency 'solrizer'
-  spec.add_dependency 'gdor-indexer', '>=0.4.1' # for new pub date methods
+  spec.add_dependency 'gdor-indexer', '>=0.5.0' # for new pub date methods
   # newer versions of harvestdor-indexer have performance improvements for collections
   spec.add_dependency 'harvestdor-indexer', '~> 2.3'
   spec.add_dependency 'rails'
-  spec.add_dependency 'blacklight-spotlight', '~> 0.6'
+  spec.add_dependency 'blacklight-spotlight', ['~> 0.6', '< 0.16.0']
   spec.add_dependency 'parallel'
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
* pub_year_isi Solr field added (to replace pub_date_sort, the icky string)
* pub_date Solr field removed (replaced by pub_year_xxx_approx_isim)
* pinned to blacklight-spotlight 0.15.0
* updates for rubocop 0.36.0