### PR TITLE
Capitalize donor tags

### DIFF
--- a/lib/spotlight/dor/indexer.rb
+++ b/lib/spotlight/dor/indexer.rb
@@ -152,7 +152,7 @@ module Spotlight::Dor
 
       def add_donor_tags(sdb, solr_doc)
         donor_tags = sdb.smods_rec.note.select { |n| n.displayLabel == 'Donor tags' }.map(&:content)
-        insert_field solr_doc, 'donor_tags', donor_tags, :symbol # this is a _ssim field
+        insert_field solr_doc, 'donor_tags', upcase_first_character(donor_tags), :symbol # this is a _ssim field
       end
 
       # add the folder name to solr_doc as folder_name_ssi field (note: single valued!)
@@ -211,6 +211,12 @@ module Spotlight::Dor
           "//contentMetadata/resource/file[@id=\"#{sdb.bare_druid}.txt\"]" # feigenbaum style - full text in .txt named for druid
         ]
       end
+    end
+
+    # takes an array, upcases just the first character of each element in the array and returns the new array
+    #   not the same as .captialize which will lowercase the rest of the string
+    def upcase_first_character(values)
+      values.map { |value| value.sub(/^./, &:upcase) }
     end
 
     def insert_field(solr_doc, field, values, *args)

--- a/lib/spotlight/dor/resources/version.rb
+++ b/lib/spotlight/dor/resources/version.rb
@@ -2,7 +2,7 @@ module Spotlight
   module Dor
     # :nodoc:
     module Resources
-      VERSION = '1.0.0'
+      VERSION = '1.0.1'
     end
   end
 end

--- a/spec/lib/spotlight/dor/indexer_spec.rb
+++ b/spec/lib/spotlight/dor/indexer_spec.rb
@@ -141,6 +141,7 @@ describe Spotlight::Dor::Indexer do
             <mods xmlns="#{Mods::MODS_NS}">
               <note displayLabel="Donor tags">Knowledge Systems Laboratory</note>
               <note displayLabel="Donor tags">medical applications</note>
+              <note displayLabel="Donor tags">medical Applications (second word CAPPED)</note>
               <note displayLabel="Donor tags">Publishing</note>
               <note displayLabel="Donor tags">Stanford</note>
               <note displayLabel="Donor tags">Stanford Computer Science Department</note>
@@ -150,7 +151,8 @@ describe Spotlight::Dor::Indexer do
 
         it 'extracts the donor tags' do
           expect(solr_doc['donor_tags_ssim']).to contain_exactly 'Knowledge Systems Laboratory',
-                                                                 'medical applications',
+                                                                 'Medical applications',
+                                                                 'Medical Applications (second word CAPPED)',
                                                                  'Publishing',
                                                                  'Stanford',
                                                                  'Stanford Computer Science Department'


### PR DESCRIPTION
allows donor tags to be shown/sorted together in the facet (no odd case-sensitive sort)
